### PR TITLE
Create clean-up-diskspace.sh

### DIFF
--- a/ubuntu/code/bash/clean-up-diskspace.sh
+++ b/ubuntu/code/bash/clean-up-diskspace.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+echo "Cleaning up space, removing packages no longer required"
+sudo apt autoremove
+
+echo "Cleaning up space with journalctl"
+sudo journalctl --disk-usage
+sudo journalctl --vacuum-time=3d
+
+echo "Cleaning up space, removing apt cache"
+sudo du -sh /var/cache/apt 
+sudo apt clean
+
+echo "Cleaning up space, removing thumbnails cache"
+du -sh ~/.cache/thumbnails
+rm -rf ~/.cache/thumbnails/*
+
+# Removes old revisions of snaps
+# CLOSE ALL SNAPS BEFORE RUNNING THIS
+read -p "CLOSE ALL SNAPS BEFORE RUNNING THIS, then Press Enter to continue" < /dev/tty
+
+du -h /var/lib/snapd/snaps
+
+set -eu
+sudo snap list --all | awk '/disabled/{print $1, $3}' |
+    while read snapname revision; do
+        sudo snap remove "$snapname" --revision="$revision"
+    done
+
+echo "Old revisions of snaps cleaned, you have now this much space used by snaps"
+du -h /var/lib/snapd/snaps


### PR DESCRIPTION
Clean up disk space script that can be run periodically. It removes packages no longer required, journals older then 3 days, apt cache, thumbnails cache and snaps that are older versions of what is currently used.